### PR TITLE
Disabling the ability to add tests if tests disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ include(Dependencies)
 # Testing
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 enable_testing()
+set(ENABLE_TEST_TARGETS ON)
 {% endif %}
 
 # Install includes

--- a/Dependencies.cmake
+++ b/Dependencies.cmake
@@ -22,9 +22,9 @@ FetchContent_Declare(
 {% endif %}
 
 FetchContent_Declare(
-  cxxopts
-  GIT_REPOSITORY https://github.com/jarro2783/cxxopts.git
-  GIT_TAG v3.2.1
+  structopt
+  GIT_REPOSITORY https://github.com/p-ranav/structopt.git
+  GIT_TAG master
 )
 
 FetchContent_Declare(
@@ -34,6 +34,20 @@ FetchContent_Declare(
   SYSTEM
 )
 
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt
+  GIT_TAG e69e5f977d458f2650bb346dadf2ad30c5320281
+)
+
 {% if cpr.testing_enabled %}FetchContent_MakeAvailable(catch2){% endif %}
-FetchContent_MakeAvailable(cxxopts)
+FetchContent_MakeAvailable(structopt)
 FetchContent_MakeAvailable(backward)
+FetchContent_MakeAvailable(fmt)
+
+set(USE_VENDOR_TARGETS 
+  structopt::structopt
+  Backward::Object
+  fmt::fmt
+)
+{% if cpr.testing_enabled %}set(USE_TEST_VENDOR_TARGETS "${USE_VENDOR_TARGETS}" Catch2::Catch2WithMain){% endif %}

--- a/cmake/TargetMacros.cmake
+++ b/cmake/TargetMacros.cmake
@@ -59,11 +59,9 @@ function(newTarget targetName)
     )
 
     # Add vendor libraries
-    target_link_libraries(
-        ${targetName}
-        PRIVATE cxxopts::cxxopts
-        PRIVATE Backward::Backward
-    )
+    foreach(lib ${USE_VENDOR_TARGETS})
+        target_link_libraries(${targetName} PUBLIC ${lib})
+    endforeach()
 
     if(NT_LINK_LIBS)
         target_link_libraries(${targetName} PUBLIC ${NT_LINK_LIBS})
@@ -127,6 +125,11 @@ endfunction()
 #   Sources for target
 #
 function(newTest testName)
+    if (NOT ENABLE_TEST_TARGETS)
+        message(STATUS "Tests are disabled")
+        return()
+    endif()
+
     cmake_parse_arguments(NT "AGAINST" "SOURCES" ${ARGN})
 
     if(NOT __NT_${NT_AGAINST}_exists)
@@ -146,11 +149,9 @@ function(newTest testName)
     )
 
     # Add vendor libraries
-    target_link_libraries(
-        ${testName}
-        PRIVATE Backward::Backward
-        PRIVATE Catch2::Catch2WithMain
-    )
+    foreach(lib ${USE_TEST_VENDOR_TARGETS})
+        target_link_libraries(${testName} PRIVATE ${lib})
+    endforeach()
 
     if(NOT __FT_${NT_AGAINST}_is_binary)
         target_link_libraries(${testName} PRIVATE ${NT_AGAINST})


### PR DESCRIPTION
Users are still able to use `newTest` in `cmake/TargetMacros.cmake`. This change fixes that behaviour as well as alters how dependencies are handled.